### PR TITLE
feat: init terraform for cognito

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.code-workspace
+
+*.secret.*
+
+.DS_Store

--- a/infra/aws/terraform/.gitignore
+++ b/infra/aws/terraform/.gitignore
@@ -1,0 +1,40 @@
+# Created by https://www.toptal.com/developers/gitignore/api/terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=terraform
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# End of https://www.toptal.com/developers/gitignore/api/terraform

--- a/infra/aws/terraform/.gitignore
+++ b/infra/aws/terraform/.gitignore
@@ -19,7 +19,7 @@ crash.*.log
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
-
+!*.example.tfvars
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
 override.tf

--- a/infra/aws/terraform/.terraform.lock.hcl
+++ b/infra/aws/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/aws/terraform/Makefile
+++ b/infra/aws/terraform/Makefile
@@ -1,4 +1,4 @@
-.PHONY: apply init 
+.PHONY: init plan-dev apply-dev destroy-dev
 
 init: 
 	terraform init

--- a/infra/aws/terraform/Makefile
+++ b/infra/aws/terraform/Makefile
@@ -1,9 +1,13 @@
-.PHONY: apply
+.PHONY: apply init 
 
-apply:
-	terraform apply -auto-approve
+init: 
+	terraform init
+
+plan-dev:
+	terraform plan -var-file=env/dev/terraform.tfvars
 
 apply-dev:
-	# destroy existing resources in dev environment
-	terraform destroy -var-file=env/dev/terraform.tfvars -auto-approve || true
 	terraform apply -var-file=env/dev/terraform.tfvars -auto-approve
+
+destroy-dev:
+	terraform destroy -var-file=env/dev/terraform.tfvars -auto-approve

--- a/infra/aws/terraform/Makefile
+++ b/infra/aws/terraform/Makefile
@@ -1,0 +1,9 @@
+.PHONY: apply
+
+apply:
+	terraform apply -auto-approve
+
+apply-dev:
+	# destroy existing resources in dev environment
+	terraform destroy -var-file=env/dev/terraform.tfvars -auto-approve || true
+	terraform apply -var-file=env/dev/terraform.tfvars -auto-approve

--- a/infra/aws/terraform/README.md
+++ b/infra/aws/terraform/README.md
@@ -1,0 +1,29 @@
+# Terraform Project
+
+This Terraform project manages infras of expense-tracking project.
+
+## Usage
+
+```bash
+# Initialize
+terraform init
+
+# Plan changes
+terraform plan
+
+# Apply changes
+make apply-dev
+
+# Destroy resources
+terraform destroy
+```
+
+## Structure
+
+- `main.tf` - Main resource definitions
+- `variables.tf` - Input variable declarations
+- `outputs.tf` - Output declarations
+- `terraform.tfvars` - Variable values
+- `providers.tf` - Provider configurations
+- `/environments` - Environment-specific configurations
+- `/modules` - Reusable Terraform modules

--- a/infra/aws/terraform/README.md
+++ b/infra/aws/terraform/README.md
@@ -1,21 +1,33 @@
 # Terraform Project
 
-This Terraform project manages infras of expense-tracking project.
+This Terraform project manages infrastructure for the expense-tracking project.
 
 ## Usage
 
-```bash
-# Initialize
-terraform init
+You can use the provided `Makefile` to simplify common Terraform commands:
 
-# Plan changes
-terraform plan
+### Initialize Terraform
 
-# Apply changes
+```
+make init
+```
+
+### Plan changes for the dev environment
+
+```
+make plan-dev
+```
+
+### Apply changes to the dev environment
+
+```
 make apply-dev
+```
 
-# Destroy resources
-terraform destroy
+### Destroy resources in the dev environment
+
+```
+make destroy-dev
 ```
 
 ## Structure
@@ -27,3 +39,4 @@ terraform destroy
 - `providers.tf` - Provider configurations
 - `/environments` - Environment-specific configurations
 - `/modules` - Reusable Terraform modules
+- `Makefile` - Common Terraform commands for convenience

--- a/infra/aws/terraform/env/dev/terraform.example.tfvars
+++ b/infra/aws/terraform/env/dev/terraform.example.tfvars
@@ -1,0 +1,2 @@
+google_client_id = "your-google-client-id"
+google_client_secret = "your-gooogle-client-secret"

--- a/infra/aws/terraform/main.tf
+++ b/infra/aws/terraform/main.tf
@@ -1,16 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-}
-
-provider "aws" {
-  region = var.aws_region
-}
-
 resource "aws_cognito_user_pool" "main" {
   name = "${var.user_pool_name}-${var.environment}"
 
@@ -82,7 +69,6 @@ resource "aws_cognito_user_pool_client" "webapp" {
 
   explicit_auth_flows = [ 
     "ALLOW_USER_SRP_AUTH",
-    "ALLOW_REFRESH_TOKEN_AUTH",
-    "ALLOW_USER_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH"
    ]
 }

--- a/infra/aws/terraform/main.tf
+++ b/infra/aws/terraform/main.tf
@@ -1,0 +1,88 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_cognito_user_pool" "main" {
+  name = "${var.user_pool_name}-${var.environment}"
+
+  username_attributes = [ "email" ]
+  
+  mfa_configuration = "OFF"
+
+  account_recovery_setting {
+    recovery_mechanism {
+      priority = 1
+      name     = "verified_email"
+    }
+  }
+
+  schema {
+    name = "email"
+    attribute_data_type = "String"
+    mutable = false
+    required = true
+  }
+
+  schema {
+    name = "name"
+    attribute_data_type = "String"
+    mutable = true
+    required = true
+  }
+
+  // Required image profile and allow to mutate
+  schema {
+    name = "picture"
+    attribute_data_type = "String"
+    mutable = true
+    required = false
+  }
+}
+
+resource "aws_cognito_identity_provider" "google" {
+  user_pool_id = aws_cognito_user_pool.main.id
+  provider_name = "Google"
+  provider_type = "Google"
+
+  provider_details = {
+    client_id     = var.google_client_id
+    client_secret = var.google_client_secret
+    authorize_scopes = "email profile openid"
+  }
+
+  attribute_mapping = {
+    email   = "email"
+    name    = "name"
+    picture = "picture"
+  }
+}
+
+resource "aws_cognito_user_pool_client" "webapp" {
+  name = "${var.user_pool_name}-webapp-client"
+  user_pool_id = aws_cognito_user_pool.main.id
+
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows = [ "code" ]
+  allowed_oauth_scopes = [ "email", "openid", "profile" ]
+  supported_identity_providers = ["Google"]
+
+  callback_urls = [ "http://localhost:3000" ]
+  logout_urls = [ "http://localhost:3000" ]
+
+  generate_secret = false
+
+  explicit_auth_flows = [ 
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_AUTH",
+   ]
+}

--- a/infra/aws/terraform/main.tf
+++ b/infra/aws/terraform/main.tf
@@ -68,7 +68,6 @@ resource "aws_cognito_user_pool_client" "webapp" {
   generate_secret = false
 
   explicit_auth_flows = [ 
-    "ALLOW_USER_SRP_AUTH",
     "ALLOW_REFRESH_TOKEN_AUTH"
    ]
 }

--- a/infra/aws/terraform/providers.tf
+++ b/infra/aws/terraform/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/aws/terraform/providers.tf
+++ b/infra/aws/terraform/providers.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = "value ~> 1.12"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -19,9 +19,11 @@ variable "environment" {
 variable "google_client_id" {
   description = "Google Client ID for Cognito Identity Provider"
   type        = string
+  sensitive = false
 }
 
 variable "google_client_secret" {
   description = "Google Client Secret for Cognito Identity Provider"
   type        = string
+  sensitive = true
 }

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  description = "The AWS region to deploy resources in"
+  type        = string
+  default     = "ap-southeast-1"
+}
+
+variable "user_pool_name" {
+  description = "The name of the Cognito User Pool"
+  type        = string
+  default     = "expense-tracker-user-pool"
+}
+
+variable "environment" {
+  description = "value of the environment"
+  type        = string
+  default     = "dev"
+}
+
+variable "google_client_id" {
+  description = "Google Client ID for Cognito Identity Provider"
+  type        = string
+}
+
+variable "google_client_secret" {
+  description = "Google Client Secret for Cognito Identity Provider"
+  type        = string
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Terraform configuration for AWS Cognito user authentication, including support for Google as an identity provider.
  * Added variables for customizable AWS region, environment, and Google OAuth credentials.
  * Provided a Makefile for streamlined Terraform apply operations.
  * Included a README with setup and usage instructions for infrastructure management.

* **Chores**
  * Updated and added .gitignore files to exclude sensitive, system, and Terraform-related files from version control.
  * Added a lock file to ensure consistent Terraform provider versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->